### PR TITLE
commented check_result_buffer_slots because no longer available in Nagios 3.5.0

### DIFF
--- a/files/configs/CentOS/nagios.cfg
+++ b/files/configs/CentOS/nagios.cfg
@@ -399,7 +399,8 @@ service_reaper_frequency=10
 # service check results before they are processed.  As check results
 # are processed by the daemon, they are removed from the buffer.  
 
-check_result_buffer_slots=4096
+# commented because no longer available in Nagios 3.5.0
+# check_result_buffer_slots=4096
 
 
 


### PR DESCRIPTION
Starting Nagios 3.5.0 fails citing an error at line 402 in files/configs/CentOS/nagios.cfg.  This branch fixes that error by commenting the check_result_buffer_slots directive.
